### PR TITLE
Bugfix: make "safe" char offset actually safe

### DIFF
--- a/lib/Debugger/UI/CommandLine.pm
+++ b/lib/Debugger/UI/CommandLine.pm
@@ -98,8 +98,8 @@ my class SourceFile {
         @lines.map: {
             state $line = 0;
             NEXT $line++;
-            my $safe_start_pos = [min] $start_line_pos, .chars - 1;
-            my $safe_end_pos   = [min] $end_line_pos, .chars - 1;
+            my $safe_start_pos = [min] $start_line_pos, .chars;
+            my $safe_end_pos   = [min] $end_line_pos, .chars;
             my $rendered       = colored('| ', 'blue');
             if $line == 0 && $line == @lines.end {
                 $rendered ~= .substr(0, $safe_start_pos);


### PR DESCRIPTION
The debugger crashed when stopping at a statement that included a blank line. Golfed test case:

{1

} 

I did not see any new problems when testing this bugfix with the test case, some variants of it, and with a 200 line script that I'm working on and which happened to trigger this bug.
