### PR TITLE
10x+ speedup when 100 line script with breakpoints

### DIFF
--- a/lib/Debugger/UI/CommandLine.pm
+++ b/lib/Debugger/UI/CommandLine.pm
@@ -64,12 +64,15 @@ my class SourceFile {
             );
         @best ?? @best[0].value.name !! ''
     }
-    
+
+    # replace manual cache with original code plus 'is cached' routine trait when it works:
     method line_of($pos, $def_line, $def_pos) {
         my $last_p = 0;
+        state %cache; if %cache{$pos} { return |%cache{$pos} };
         for @!line_offsets.kv -> $l, $p {
             if $p > $pos {
-                return ($l - 1, abs($pos - $last_p));
+                %cache{$pos} = ($l - 1, abs($pos - $last_p));
+                return |%cache{$pos};
             }
             $last_p = $p;
         }

--- a/lib/Debugger/UI/CommandLine.pm
+++ b/lib/Debugger/UI/CommandLine.pm
@@ -22,6 +22,7 @@ my class SourceFile {
     has $.source;
     has @!lines;
     has @!line_offsets;
+    has %!line_of_cache;
     has @!regex_regions;
     has %!routine_regions{Range};
     
@@ -68,11 +69,11 @@ my class SourceFile {
     # replace manual cache with original code plus 'is cached' routine trait when it works:
     method line_of($pos, $def_line, $def_pos) {
         my $last_p = 0;
-        state %cache; if %cache{$pos} { return |%cache{$pos} };
+        if %!line_of_cache{$pos} { return |%!line_of_cache{$pos} };
         for @!line_offsets.kv -> $l, $p {
             if $p > $pos {
-                %cache{$pos} = ($l - 1, abs($pos - $last_p));
-                return |%cache{$pos};
+                %!line_of_cache{$pos} = ($l - 1, abs($pos - $last_p));
+                return |%!line_of_cache{$pos};
             }
             $last_p = $p;
         }


### PR DESCRIPTION
line_of method needs a cache to reasonably handle larger / longer running scripts.

First tried lizmat++'s new 'is cached' trait but that caused an infinite loop somewhere.

So this patch is a manually written cache.
