### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Debugger/UI/CommandLine.pm
+++ b/lib/Debugger/UI/CommandLine.pm
@@ -1,4 +1,4 @@
-module Debug::UI::CommandLine;
+unit module Debug::UI::CommandLine;
 
 use Term::ANSIColor;
 use nqp;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.